### PR TITLE
Fix setState misuse

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -27,6 +27,7 @@ class ProfileScreenState extends State<ProfileScreen> {
 
   Future<void> _loadProfiles() async {
     final list = await _profileManager.getProfiles();
+    if (!mounted) return;
     setState(() {
       _profiles = list;
       _isLoading = false;

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -45,9 +45,11 @@ class VideoPlayerPageState extends State<VideoPlayerPage> {
       if (kDebugMode) {
         print("Failed to play video: '${e.message}'.");
       }
-      setState(() {
-        _errorMessage = e.message;
-      });
+      if (mounted) {
+        setState(() {
+          _errorMessage = e.message;
+        });
+      }
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/widgets/add_profile_widget.dart
+++ b/lib/widgets/add_profile_widget.dart
@@ -45,9 +45,11 @@ Future<void> _pickImage() async {
     },
   );
 
+  if (!mounted) return;
+
   if (source != null) {
     final image = await picker.pickImage(source: source);
-    if (image != null) {
+    if (image != null && mounted) {
       setState(() {
         _imagePath = image.path;
       });


### PR DESCRIPTION
## Summary
- avoid calling setState after dispose in video player
- guard against disposed widgets in profile loading
- check mounted before setting picked profile image